### PR TITLE
Add option to build using vcpkg for dependencies

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,19 +1,24 @@
 {
-    "version": 3,
-    "configurePresets": [
-        {
-            "name": "default",
-            "binaryDir": "build/${presetName}",
-            "cacheVariables": {
-                "BUILD_SAMPLES": true,
-                "CMAKE_INSTALL_PREFIX": "install/${presetName}"
-            }
-        }
-    ],
-    "buildPresets": [
-        {
-            "name":"default",
-            "configurePreset": "default"
-        }
-    ]
+  "version": 3,
+  "configurePresets": [
+    {
+      "name": "default",
+      "binaryDir": "build/${presetName}",
+      "cacheVariables": {
+        "BUILD_SAMPLES": true,
+        "CMAKE_INSTALL_PREFIX": "install/${presetName}"
+      }
+    },
+    {
+      "name": "vcpkg",
+      "inherits": [ "default" ],
+      "toolchainFile": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "default",
+      "configurePreset": "default"
+    }
+  ]
 }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -12,7 +12,12 @@
     {
       "name": "vcpkg",
       "inherits": [ "default" ],
-      "toolchainFile": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+      "toolchainFile": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+      "condition": {
+        "type": "notEquals",
+        "lhs": "$env{VCPKG_ROOT}",
+        "rhs": ""
+      }
     }
   ],
   "buildPresets": [

--- a/crogine/CMakeLists.txt
+++ b/crogine/CMakeLists.txt
@@ -73,8 +73,6 @@ else()
   add_definitions(-DCRO_BUILD)
 endif()
 
-SET (CMAKE_CXX_FLAGS_DEBUG "-g -DCRO_DEBUG_ -DHAS_SOCKLEN_T")
-SET (CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG -DHAS_SOCKLEN_T")
 SET (CMAKE_DEBUG_POSTFIX -d)
 
 # We're using c++17
@@ -156,6 +154,7 @@ if(NOT TARGET crogine)
     add_library(${PROJECT_NAME} SHARED ${PROJECT_SRC})
   endif()
 
+  target_compile_definitions(${PROJECT_NAME} PUBLIC $<$<CONFIG:Debug>:CRO_DEBUG_>)
 
   target_link_libraries(${PROJECT_NAME}
     ${SDL2_LIBRARY} 

--- a/samples/golf/CMakeLists.txt
+++ b/samples/golf/CMakeLists.txt
@@ -43,9 +43,6 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wno-potentially-evaluated-expression")
 endif()
 
-SET(CMAKE_CXX_FLAGS_DEBUG "-g -DCRO_DEBUG_")
-SET(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG")
-
 if(USE_NEWSFEED)
   #add_definitions(-DUSE_RSS) #doesn't work?
   add_compile_definitions(USE_RSS)
@@ -60,7 +57,6 @@ SET(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 SET(OpenGL_GL_PREFERENCE "GLVND")
 
-find_package(CROGINE REQUIRED)
 find_package(SDL2 REQUIRED)
 find_package(OpenGL REQUIRED)
 #TODO specify version 2.83
@@ -68,16 +64,14 @@ find_package(Bullet REQUIRED)
 find_package(SQLite3 REQUIRED)
 
 if(USE_NEWSFEED)
-find_package(CURL REQUIRED)
+  find_package(CURL REQUIRED)
 endif()
 
-if(NOT CROGINE_FOUND)
-  #build it from source
-  add_subdirectory(../../crogine)
-
-  #SET (CROGINE_INCLUDE_DIR ../../crogine/include)
-  #SET (CROGINE_LIBRARIES TODO set lib output dir)
-
+# If the crogine target exists then we're being built as part of the crogine project
+# so can link to it directly. If not, we must find a pre-installed version
+if(NOT TARGET crogine)
+  # We are configuring golf standalone, so must find a crogine installation
+  find_package(CROGINE REQUIRED)
 endif()
 
 
@@ -109,10 +103,6 @@ include_directories(
   ${SQLite3_INCLUDE_DIRS}
   ${SOCIAL_INCLUDE_DIR}
   src)
-
-if(USE_NEWSFEED)
-  include_directories(${CURL_INCLUDE_DIR})
-endif()
 
 if(USE_GNS)
   include_directories(${STEAMWORKS_INCLUDE_DIR})
@@ -189,7 +179,7 @@ else()
                  ${GOLF_SRC})
 endif()
 
-
+target_compile_definitions(${PROJECT_NAME} PRIVATE $<$<CONFIG:Debug>:CRO_DEBUG_>)
 
 
 target_link_libraries(${PROJECT_NAME}
@@ -199,8 +189,12 @@ target_link_libraries(${PROJECT_NAME}
   ${SQLite3_LIBRARIES}  
   ${OPENGL_LIBRARIES})
 
+if (TARGET crogine)
+ target_link_libraries(${PROJECT_NAME} crogine)
+endif()
+
 if(USE_NEWSFEED)
-  target_link_libraries(${PROJECT_NAME} ${CURL_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME} CURL::libcurl)
 endif()
 
 if(USE_GNS)

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,0 +1,14 @@
+{
+  "default-registry": {
+    "kind": "git",
+    "baseline": "000d1bda1ffa95a73e0b40334fa4103d6f4d3d48",
+    "repository": "https://github.com/microsoft/vcpkg"
+  },
+  "registries": [
+    {
+      "kind": "artifact",
+      "location": "https://github.com/microsoft/vcpkg-ce-catalog/archive/refs/heads/main.zip",
+      "name": "microsoft"
+    }
+  ]
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": [
+    "bullet3",
+    "sdl2",
+    "sqlite3",
+    "curl"
+  ]
+}


### PR DESCRIPTION
Trying to be a bit more measured with my cmake/project updating, as my memory of previous attempts have been replaced by the paw patrol theme tune on repeat along with every word to all 3 trolls movies...

This just adds the option to build using vcpkg for dependencies which simplifies and encapsulates things a bit more - Allows users to just open the folder in visual studio and build, without having to install dependencies manually. Considered instead using the pre-built dependencies you use in your pre-configured project, but using this method instead means I can also easily work on my mac using the same workflow.

In theory, this shouldn't break any of your existing workflows/processes, but that's caught me out before so hoping the github actions will tell me if anything I've done is wrong...

Will add a few more specific comments on the diff to explain things