### PR TITLE
Mac build

### DIFF
--- a/crogine/CMakeLists.txt
+++ b/crogine/CMakeLists.txt
@@ -4,15 +4,6 @@ cmake_minimum_required(VERSION 3.5.0)
 if(APPLE)
   #required for std::filesystem
   SET(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING "Minimum OS X deployment version")
-
-  #force macOS to use homebrew installed libs, eg OpenAL
-  SET(CMAKE_PREFIX_PATH 
-	"/opt/homebrew"
-	"/opt/homebrew/opt/openal-soft/include"
-	"/opt/homebrew/opt/openal-soft/lib"
-	"/usr/local"
-	"/usr/local/opt/openal-soft/include"
-	"/usr/local/opt/openal-soft/lib")
   SET(CMAKE_FIND_FRAMEWORK LAST)
 endif()
 
@@ -81,16 +72,13 @@ SET (CMAKE_CXX_STANDARD_REQUIRED ON)
 
 SET (OpenGL_GL_PREFERENCE "GLVND")
 
-find_package(SDL2 REQUIRED)
+find_package(SDL2 MODULE REQUIRED)
 find_package(Freetype REQUIRED)
 find_package(OpenGL REQUIRED)
 find_package(OPUS REQUIRED)
 
 if(USE_OPENAL)
-#we were using mojoal on mac but now trying to get openal-soft to work from brew
-  #if(NOT APPLE)
-    find_package(OpenAL REQUIRED)
-  #endif()
+  find_package(OpenAL REQUIRED)
 else()
   find_package(SDL2_mixer REQUIRED)
 endif()
@@ -112,18 +100,13 @@ if(MSVC)
   include_directories(${CMAKE_SOURCE_DIR}/extlibs/openal/include ${DBGHELP_INCLUDE_DIR})
 elseif(LINUX)
   include_directories(${LIBUNWIND_INCLUDE_DIRS})
-elseif(APPLE)
-  include_directories(/usr/local/opt/openal-soft/include)
-  link_directories(/usr/local/opt/openal-soft/lib)
 endif()
 
 SET(PROJECT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src)
 include(${PROJECT_DIR}/CMakeLists.txt)
 
 if(USE_OPENAL)
-  #if(NOT APPLE)
-    include_directories(${OPENAL_INCLUDE_DIR})
-  #endif()
+  include_directories(${OPENAL_INCLUDE_DIR})
   SET(PROJECT_SRC ${PROJECT_SRC} ${project_src_openal})
 else()
   include_directories(${SDL2_MIXER_INCLUDE_DIR})
@@ -163,9 +146,7 @@ if(NOT TARGET crogine)
     ${OPENGL_LIBRARIES})
 
   if(USE_OPENAL)
-    #if(NOT APPLE)
-      target_link_libraries(${PROJECT_NAME} ${OPENAL_LIBRARY})
-    #endif()
+    target_link_libraries(${PROJECT_NAME} ${OPENAL_LIBRARY})
   else()
     target_link_libraries(${PROJECT_NAME} ${SDL2_MIXER_LIBRARY})
   endif()

--- a/editor/cmake/modules/FindSDL2.cmake
+++ b/editor/cmake/modules/FindSDL2.cmake
@@ -75,6 +75,7 @@ SET(SDL2_SEARCH_PATHS
 	/sw # Fink
 	/opt/local # DarwinPorts
 	/opt/csw # Blastwave
+	/opt/homebrew # homebrew
 	/opt
 	${SDL2_PATH}
 )

--- a/libsocial/include/Input.hpp
+++ b/libsocial/include/Input.hpp
@@ -123,7 +123,7 @@ namespace Progress
         }
     }
 
-    static inline bool read(std::int32_t leagueID, std::size_t& holeIndex, std::vector<std::uint8_t>& holeScores)
+    static inline bool read(std::int32_t leagueID, std::uint64_t& holeIndex, std::vector<std::uint8_t>& holeScores)
     {
         CRO_ASSERT(!holeScores.empty(), "");
 

--- a/samples/golf/CMakeLists.txt
+++ b/samples/golf/CMakeLists.txt
@@ -119,10 +119,10 @@ include(${PROJECT_DIR}/sqlite/CMakeLists.txt)
 include(${SOCIAL_DIR}/CMakeLists.txt)
 
 SET(GOLF_SRC ${GOLF_SRC} ${SOCIAL_SRC} ${EDITOR_SRC} ${ENDLESS_SRC} ${SQLITE_SRC})
-#if(USE_NEWSFEED) #we actually use this in steam version now too
+if(USE_NEWSFEED)
   include(${PROJECT_DIR}/rss/CMakeLists.txt)
   SET(GOLF_SRC ${GOLF_SRC} ${RSS_SRC})
-#endif()
+endif()
 
 if(USE_GNS)
   #include source of workshop, libgns

--- a/samples/golf/CMakeLists.txt
+++ b/samples/golf/CMakeLists.txt
@@ -154,9 +154,6 @@ if(APPLE)
      SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
   ENDIF("${isSystemDir}" STREQUAL "-1")
 
-  set_source_files_properties(
-      ${CMAKE_SOURCE_DIR}/icon.icns PROPERTIES MACOSX_PACKAGE_LOCATION Resources )
-
   set_target_properties(${PROJECT_NAME} PROPERTIES MACOSX_BUNDLE TRUE)
 
   # Add the assets if the folder ezists
@@ -166,6 +163,10 @@ if(APPLE)
     set_source_files_properties(${ASSETS_PATH} PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
   endif()
 
+  # Add the icon
+  set(ICON_PATH ${CMAKE_CURRENT_SOURCE_DIR}/macOS/icon.icns)
+  target_sources(${PROJECT_NAME} PRIVATE ${ICON_PATH})
+  set_source_files_properties(${ICON_PATH} PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
   set_target_properties(${PROJECT_NAME} PROPERTIES MACOSX_BUNDLE_ICON_FILE icon.icns)
 
 endif()

--- a/samples/golf/CMakeLists.txt
+++ b/samples/golf/CMakeLists.txt
@@ -16,11 +16,11 @@ if(NOT CMAKE_BUILD_TYPE)
   SET(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build (Debug or Release)" FORCE)
 endif()
 
-option(USE_NEWSFEED "Set to true to attempt to parse RSS newsfeed from itchio. Requires libcurl" TRUE)
+option(USE_NEWSFEED "Set to true to attempt to parse RSS newsfeed from itchio. Requires libcurl" ON)
+option(USE_STEAM "Enable the steamworks SDK" OFF)
 
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/../cmake/modules/")
 SET (PROJECT_STATIC_RUNTIME FALSE)
-SET (USE_GNS FALSE CACHE STRING "Can't use newsfeed with this")
 
 if(CMAKE_COMPILER_IS_GNUCXX OR APPLE)
   if(PROJECT_STATIC_RUNTIME)
@@ -66,18 +66,19 @@ if(NOT TARGET crogine)
 endif()
 
 
-if(USE_GNS)
-  if(USE_NEWSFEED)
-  message(FATAL_ERROR "Can't use newsfeed with GNS builds. Set USE_NEWSFEED to false")
-  endif()
+if(USE_STEAM)
 
   add_compile_definitions(USE_GNS)
 
+  include(FetchContent)
+  FetchContent_Declare(libgns
+    GIT_REPOSITORY https://github.com/fallahn/libgns) # Could specify a tag/commit hash here?
+  FetchContent_MakeAvailable(libgns)
 
-  SET(GNS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../libgns)
+  SET(GNS_DIR ${libgns_SOURCE_DIR})
   SET(SOCIAL_DIR ${GNS_DIR}/golf_ach/src)
   SET(SOCIAL_INCLUDE_DIR ${GNS_DIR}/golf_ach/include)
-  SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${GNS_DIR}/cmake/modules/")
+  SET(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${GNS_DIR}/cmake/modules/")
   find_package(STEAMWORKS REQUIRED)
 
 else()
@@ -95,7 +96,7 @@ include_directories(
   ${SOCIAL_INCLUDE_DIR}
   src)
 
-if(USE_GNS)
+if(USE_STEAM)
   include_directories(${STEAMWORKS_INCLUDE_DIR})
   include_directories(${GNS_DIR}/golf_workshop/include)
   include_directories(${GNS_DIR}/libgns/include)
@@ -115,7 +116,7 @@ if(USE_NEWSFEED)
   SET(GOLF_SRC ${GOLF_SRC} ${RSS_SRC})
 endif()
 
-if(USE_GNS)
+if(USE_STEAM)
   #include source of workshop, libgns
   include(${GNS_DIR}/golf_workshop/src/CMakeLists.txt)
   include(${GNS_DIR}/libgns/src/CMakeLists.txt)
@@ -183,22 +184,22 @@ if(USE_NEWSFEED)
   target_link_libraries(${PROJECT_NAME} CURL::libcurl)
 endif()
 
-if(USE_GNS)
+if(USE_STEAM)
   target_link_libraries(${PROJECT_NAME} ${STEAMWORKS_LIBRARIES})
 endif()
 
-# install to the bundle
 if(APPLE)
+  # Install the app bundle to the root install folder
+  install(TARGETS ${PROJECT_NAME} DESTINATION .)
 
-  install(TARGETS ${PROJECT_NAME}
-    RUNTIME DESTINATION .
-    BUNDLE DESTINATION ${CMAKE_SOURCE_DIR}/bundle)
-
-
+  # Use fixup_bundle to ensure all libs are copied into the bundle
+  # Then sign with ad-hoc signing
   install(CODE " include(BundleUtilities)
-    fixup_bundle(${CMAKE_SOURCE_DIR}/bundle/${PROJECT_NAME}.app \"\" \"/Library/Frameworks\")
-    verify_app(${CMAKE_SOURCE_DIR}/bundle/${PROJECT_NAME}.app)")
-    SET(CPACK_GENERATOR "DragNDrop")
+    fixup_bundle(${CMAKE_INSTALL_PREFIX}/${PROJECT_NAME}.app \"\" 
+    \"/Library/Frameworks;$<TARGET_FILE_DIR:crogine>;${CMAKE_INSTALL_PREFIX}/lib;${GNS_DIR}/extlibs/steam/bin\")
+    execute_process(COMMAND codesign -f -s \"-\" --deep ${CMAKE_INSTALL_PREFIX}/${PROJECT_NAME}.app COMMAND_ECHO STDOUT)
+    execute_process(COMMAND codesign -vvvv ${CMAKE_INSTALL_PREFIX}/${PROJECT_NAME}.app COMMAND_ECHO STDOUT)")
+  set(CPACK_GENERATOR "DragNDrop")
 
   include(CPack)
 

--- a/samples/golf/CMakeLists.txt
+++ b/samples/golf/CMakeLists.txt
@@ -16,7 +16,7 @@ if(NOT CMAKE_BUILD_TYPE)
   SET(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build (Debug or Release)" FORCE)
 endif()
 
-option(USE_NEWSFEED "Set to true to attempt to parse RSS newsfeed from itchio. Requires libcurl" ON)
+#option(USE_NEWSFEED "Set to true to attempt to parse RSS newsfeed from itchio. Requires libcurl" ON)
 option(USE_STEAM "Enable the steamworks SDK" OFF)
 
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/../cmake/modules/")
@@ -34,11 +34,9 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wno-potentially-evaluated-expression")
 endif()
 
-if(USE_NEWSFEED)
-  #add_definitions(-DUSE_RSS) #doesn't work?
-  add_compile_definitions(USE_RSS)
-  #add_compile_definitions(-DUSE_RSS) #can't find a definitive answer on this...
-endif()
+#if(USE_NEWSFEED)
+#  add_compile_definitions(USE_RSS)
+#endif()
 
 
 
@@ -54,7 +52,7 @@ find_package(OpenGL REQUIRED)
 find_package(Bullet REQUIRED)
 find_package(SQLite3 REQUIRED)
 
-if(USE_NEWSFEED)
+if(NOT USE_STEAM)
   find_package(CURL REQUIRED)
 endif()
 
@@ -111,10 +109,11 @@ include(${PROJECT_DIR}/sqlite/CMakeLists.txt)
 include(${SOCIAL_DIR}/CMakeLists.txt)
 
 SET(GOLF_SRC ${GOLF_SRC} ${SOCIAL_SRC} ${EDITOR_SRC} ${ENDLESS_SRC} ${SQLITE_SRC})
-if(USE_NEWSFEED)
+#Steam version actually uses this too now...
+#if(USE_NEWSFEED)
   include(${PROJECT_DIR}/rss/CMakeLists.txt)
   SET(GOLF_SRC ${GOLF_SRC} ${RSS_SRC})
-endif()
+#endif()
 
 if(USE_STEAM)
   #include source of workshop, libgns
@@ -180,12 +179,14 @@ if (TARGET crogine)
  target_link_libraries(${PROJECT_NAME} crogine)
 endif()
 
-if(USE_NEWSFEED)
-  target_link_libraries(${PROJECT_NAME} CURL::libcurl)
-endif()
+#if(USE_NEWSFEED)
+#  target_link_libraries(${PROJECT_NAME} CURL::libcurl)
+#endif()
 
 if(USE_STEAM)
   target_link_libraries(${PROJECT_NAME} ${STEAMWORKS_LIBRARIES})
+else()
+  target_link_libraries(${PROJECT_NAME} CURL::libcurl)
 endif()
 
 if(APPLE)

--- a/samples/golf/CMakeLists.txt
+++ b/samples/golf/CMakeLists.txt
@@ -12,16 +12,11 @@ endif()
 project(golf)
 SET(PROJECT_NAME golf)
 
-
 if(NOT CMAKE_BUILD_TYPE)
   SET(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build (Debug or Release)" FORCE)
 endif()
 
-if(APPLE)
-SET(USE_NEWSFEED False CACHE STRING "Set to true to attempt to parse RSS newsfeed from itchio. Requires libcurl")
-else()
-SET(USE_NEWSFEED True CACHE STRING "Set to true to attempt to parse RSS newsfeed from itchio. Requires libcurl")
-endif()
+option(USE_NEWSFEED "Set to true to attempt to parse RSS newsfeed from itchio. Requires libcurl" TRUE)
 
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/../cmake/modules/")
 SET (PROJECT_STATIC_RUNTIME FALSE)

--- a/samples/golf/CMakeLists.txt
+++ b/samples/golf/CMakeLists.txt
@@ -1,14 +1,10 @@
 cmake_minimum_required(VERSION 3.5.2)
 
-
 #Xcode 10 will default to Mojave (must be done BEFORE project())
 if (APPLE)
  SET(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING "Minimum OS X deployment version")
- SET(MACOS_BUNDLE False CACHE BOOL "")
 
-  if(MACOS_BUNDLE)
-    SET(BUNDLE_NAME "Super Video Golf")
-  endif()
+ SET(BUNDLE_NAME "Super Video Golf")
 
 endif()
 
@@ -132,9 +128,12 @@ if(USE_GNS)
   SET(GOLF_SRC ${GOLF_SRC} ${GNS_SRC} ${WORKSHOP_SRC})
 endif()
 
+add_executable(${PROJECT_NAME}
+                ${PROJECT_SRC}
+                ${GOLF_SRC})
 
 # If on apple, create a nice bundle
-if(APPLE AND MACOS_BUNDLE)
+if(APPLE)
 
   # use, i.e. don't skip the full RPATH for the build tree
   SET(CMAKE_SKIP_BUILD_RPATH FALSE)
@@ -155,32 +154,23 @@ if(APPLE AND MACOS_BUNDLE)
      SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
   ENDIF("${isSystemDir}" STREQUAL "-1")
 
-  set_source_files_properties( 
-      ${CMAKE_SOURCE_DIR}/assets PROPERTIES MACOSX_PACKAGE_LOCATION Resources )
   set_source_files_properties(
       ${CMAKE_SOURCE_DIR}/icon.icns PROPERTIES MACOSX_PACKAGE_LOCATION Resources )
-  add_executable(${PROJECT_NAME} MACOSX_BUNDLE 
-                 ${PROJECT_SRC} 
-                 ${GOLF_SRC} 
-                 ${CMAKE_SOURCE_DIR}/assets 
-                 ${CMAKE_SOURCE_DIR}/macOS/icon.icns)
 
+  set_target_properties(${PROJECT_NAME} PROPERTIES MACOSX_BUNDLE TRUE)
+
+  # Add the assets if the folder ezists
+  set(ASSETS_PATH ${CMAKE_CURRENT_SOURCE_DIR}/assets)
+  if (EXISTS ${ASSETS_PATH})
+    target_sources(${PROJECT_NAME} PRIVATE ${ASSETS_PATH})
+    set_source_files_properties(${ASSETS_PATH} PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
+  endif()
 
   set_target_properties(${PROJECT_NAME} PROPERTIES MACOSX_BUNDLE_ICON_FILE icon.icns)
 
-
-
-else()
-
-
-  #regular make files
-  add_executable(${PROJECT_NAME}
-                 ${PROJECT_SRC}
-                 ${GOLF_SRC})
 endif()
 
 target_compile_definitions(${PROJECT_NAME} PRIVATE $<$<CONFIG:Debug>:CRO_DEBUG_>)
-
 
 target_link_libraries(${PROJECT_NAME}
   ${CROGINE_LIBRARIES}
@@ -202,7 +192,7 @@ if(USE_GNS)
 endif()
 
 # install to the bundle
-if(APPLE AND MACOS_BUNDLE)
+if(APPLE)
 
   install(TARGETS ${PROJECT_NAME}
     RUNTIME DESTINATION .

--- a/samples/golf/macOS/build.sh
+++ b/samples/golf/macOS/build.sh
@@ -12,7 +12,7 @@ cd ..
 # make sure assets have been copied into golf from latest Windows download
 mkdir build
 cd build
-cmake .. -D MACOS_BUNDLE=true -G Xcode
+cmake .. -G Xcode
 sudo -A cmake --build . --config Release --target install
 
 cd ..

--- a/samples/golf/macOS/macOS.md
+++ b/samples/golf/macOS/macOS.md
@@ -56,12 +56,12 @@ And configure CMake
 
 ```shell
 mkdir build && cd build
-cmake .. -D MACOS_BUNDLE=true -G Xcode
+cmake .. -G Xcode
 ```
 
 Alternatively you might have some luck with
 ```
-cmake .. -D MACOS_BUNDLE=true -G Xcode -D CMAKE_C_COMPILER="/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc" -D CMAKE_CXX_COMPILER="/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++"
+cmake .. -G Xcode -D CMAKE_C_COMPILER="/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc" -D CMAKE_CXX_COMPILER="/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++"
 ```
 
 To build a universal binary include the define (requires cmake 3.18 and higher and Xcode 12)

--- a/samples/golf/src/ImTheme.hpp
+++ b/samples/golf/src/ImTheme.hpp
@@ -108,17 +108,18 @@ static inline void applyImGuiStyle(SharedStateData& sd)
     //expands the default glyph set - default is 32-255
     //0xe005-0xf8ff is used by the icon font internally
     static const std::vector<ImWchar> rangesA = { 0x1, /*0xFFFF*/0xe004, 0 }; //TODO what's the third number? Plane? Terminator?
-    fonts->AddFontFromFileTTF("assets/golf/fonts/ProggyClean.ttf", 13.f, &config, rangesA.data());
     
-    fonts->AddFontFromFileTTF("assets/golf/fonts/NotoSans-Regular.ttf", 10.f, &config, fonts->GetGlyphRangesCyrillic());
-    fonts->AddFontFromFileTTF("assets/golf/fonts/NotoSans-Regular.ttf", 10.f, &config, fonts->GetGlyphRangesGreek());
-    fonts->AddFontFromFileTTF("assets/golf/fonts/NotoSans-Regular.ttf", 10.f, &config, fonts->GetGlyphRangesVietnamese());
-    fonts->AddFontFromFileTTF("assets/golf/fonts/NotoSansThai-Regular.ttf", 10.f, &config, fonts->GetGlyphRangesThai());
-    fonts->AddFontFromFileTTF("assets/golf/fonts/NotoSansKR-Regular.ttf", 10.f, &config, fonts->GetGlyphRangesKorean());
+    const auto rp = cro::FileSystem::getResourcePath();
+    fonts->AddFontFromFileTTF((rp + "assets/golf/fonts/ProggyClean.ttf").c_str(), 13.f, &config, rangesA.data());
+    fonts->AddFontFromFileTTF((rp + "assets/golf/fonts/NotoSans-Regular.ttf").c_str(), 10.f, &config, fonts->GetGlyphRangesCyrillic());
+    fonts->AddFontFromFileTTF((rp + "assets/golf/fonts/NotoSans-Regular.ttf").c_str(), 10.f, &config, fonts->GetGlyphRangesGreek());
+    fonts->AddFontFromFileTTF((rp + "assets/golf/fonts/NotoSans-Regular.ttf").c_str(), 10.f, &config, fonts->GetGlyphRangesVietnamese());
+    fonts->AddFontFromFileTTF((rp + "assets/golf/fonts/NotoSansThai-Regular.ttf").c_str(), 10.f, &config, fonts->GetGlyphRangesThai());
+    fonts->AddFontFromFileTTF((rp + "assets/golf/fonts/NotoSansKR-Regular.ttf").c_str(), 10.f, &config, fonts->GetGlyphRangesKorean());
     //fonts->AddFontFromFileTTF("assets/golf/fonts/ark-pixel-10px-monospaced-ko.ttf", 10.f, &config, fonts->GetGlyphRangesKorean());
-    fonts->AddFontFromFileTTF("assets/golf/fonts/NotoSansJP-Regular.ttf", 10.f, &config, fonts->GetGlyphRangesJapanese());
+    fonts->AddFontFromFileTTF((rp + "assets/golf/fonts/NotoSansJP-Regular.ttf").c_str(), 10.f, &config, fonts->GetGlyphRangesJapanese());
     //fonts->AddFontFromFileTTF("assets/golf/fonts/ark-pixel-10px-monospaced-ja.ttf", 10.f, &config, fonts->GetGlyphRangesJapanese());
-    fonts->AddFontFromFileTTF("assets/golf/fonts/NotoSansTC-Regular.ttf", 10.f, &config, fonts->GetGlyphRangesChineseFull());
+    fonts->AddFontFromFileTTF((rp + "assets/golf/fonts/NotoSansTC-Regular.ttf").c_str(), 10.f, &config, fonts->GetGlyphRangesChineseFull());
     //fonts->AddFontFromFileTTF("assets/golf/fonts/ark-pixel-10px-monospaced-zh_cn.ttf", 10.f, &config, fonts->GetGlyphRangesChineseFull());
     
     static const std::vector<ImWchar> rangesB = { 0x231a, 0x23fe, 0x256d, 0x2bd1, 0x10000, 0x10FFFF, 0 };
@@ -135,8 +136,8 @@ static inline void applyImGuiStyle(SharedStateData& sd)
     else
 #endif
     {
-        fonts->AddFontFromFileTTF("assets/golf/fonts/NotoEmoji-Regular.ttf", 13.f, &config, rangesB.data());
-        sd.chatFonts.buttonLarge = fonts->AddFontFromFileTTF("assets/golf/fonts/NotoEmoji-Regular.ttf", 18.0f, &configB, rangesB.data());
+        fonts->AddFontFromFileTTF((rp + "assets/golf/fonts/NotoEmoji-Regular.ttf").c_str(), 13.f, &config, rangesB.data());
+        sd.chatFonts.buttonLarge = fonts->AddFontFromFileTTF((rp + "assets/golf/fonts/NotoEmoji-Regular.ttf").c_str(), 18.0f, &configB, rangesB.data());
         sd.chatFonts.buttonHeight = 30.f;
     }
 

--- a/samples/golf/src/SplashScreenState.cpp
+++ b/samples/golf/src/SplashScreenState.cpp
@@ -177,7 +177,7 @@ bool SplashState::handleEvent(const cro::Event& evt)
             requestStackPush(StateID::MessageOverlay);
         }
 #ifdef USE_GNS
-#undef USE_RSS
+//#undef USE_RSS
         else
         {
             if (!Social::isSteamdeck())
@@ -186,12 +186,12 @@ bool SplashState::handleEvent(const cro::Event& evt)
             }
         }
 #endif
-#ifdef USE_RSS
+//#ifdef USE_RSS
         else
         {
             requestStackPush(StateID::News);
         }
-#endif
+//#endif
     }
 
     m_uiScene.forwardEvent(evt);
@@ -227,7 +227,7 @@ bool SplashState::simulate(float dt)
             requestStackPush(StateID::MessageOverlay);
         }
 #ifdef USE_GNS
-#undef USE_RSS
+//#undef USE_RSS
         else
         {
             if (!Social::isSteamdeck())
@@ -236,12 +236,12 @@ bool SplashState::simulate(float dt)
             }
         }
 #endif
-#ifdef USE_RSS
-    else
-    {
-        requestStackPush(StateID::News);
-    }
-#endif
+//#ifdef USE_RSS
+        else
+        {
+            requestStackPush(StateID::News);
+        }
+//#endif
     }
 
     return false;
@@ -415,12 +415,12 @@ void SplashState::loadAssets()
                             m_sharedData.errorMessage = "Welcome";
                             requestStackPush(StateID::MessageOverlay);
                         }
-#ifdef USE_RSS
+//#ifdef USE_RSS
                         else
                         {
                             requestStackPush(StateID::News);
                         }
-#endif
+//#endif
                     }
                 }
                 break;

--- a/samples/golf/src/SplashScreenState.cpp
+++ b/samples/golf/src/SplashScreenState.cpp
@@ -176,7 +176,7 @@ bool SplashState::handleEvent(const cro::Event& evt)
             m_sharedData.errorMessage = "Welcome";
             requestStackPush(StateID::MessageOverlay);
         }
-#ifdef USE_GNS
+//#ifdef USE_GNS
 //#undef USE_RSS
         else
         {
@@ -185,12 +185,12 @@ bool SplashState::handleEvent(const cro::Event& evt)
                 requestStackPush(StateID::News);
             }
         }
-#endif
+//#endif
 //#ifdef USE_RSS
-        else
-        {
-            requestStackPush(StateID::News);
-        }
+        //else
+        //{
+        //    requestStackPush(StateID::News);
+        //}
 //#endif
     }
 
@@ -226,7 +226,7 @@ bool SplashState::simulate(float dt)
             m_sharedData.errorMessage = "Welcome";
             requestStackPush(StateID::MessageOverlay);
         }
-#ifdef USE_GNS
+//#ifdef USE_GNS
 //#undef USE_RSS
         else
         {
@@ -235,12 +235,12 @@ bool SplashState::simulate(float dt)
                 requestStackPush(StateID::News);
             }
         }
-#endif
+//#endif
 //#ifdef USE_RSS
-        else
-        {
-            requestStackPush(StateID::News);
-        }
+        //else
+        //{
+        //    requestStackPush(StateID::News);
+        //}
 //#endif
     }
 

--- a/samples/golf/src/golf/NewsState.hpp
+++ b/samples/golf/src/golf/NewsState.hpp
@@ -1,6 +1,6 @@
 /*-----------------------------------------------------------------------
 
-Matt Marchant 2022 - 2023
+Matt Marchant 2022 - 2024
 http://trederia.blogspot.com
 
 Super Video Golf - zlib licence.
@@ -36,9 +36,9 @@ source distribution.
 #include <crogine/audio/AudioScape.hpp>
 #include <crogine/ecs/Scene.hpp>
 
-#if defined USE_GNS || defined USE_RSS
+//#if defined USE_GNS || defined USE_RSS
 #define RSS_ENABLED
-#endif
+//#endif
 
 struct SharedStateData;
 


### PR DESCRIPTION
Supersedes my previous attempt which included a lot of mostly unrelated cmake improvements, have focussed just on getting the Mac build process smoothed out for steam distribution, including:
- Use correct resource path when loading fonts for imgui
- Where specific (e.g. brew) search paths are needed, set them in the relevant find modules instead of globally
- Removed the `MACOS_BUNDLE` parameter, as we always want to build a bundle (unless you feel otherwise?)
- Enable `USE_NEWSFEED` on apple, previously was a bit of a mishmash where it was disabled but then commented out in some places
- rename `USE_GNS` to `USE_STEAM`, and fetch libgns from the git repo when this option is enabled as it's a prerequisite
- Bit of tidying up the way resources are handled to ensure they are correctly part of the app bundle
- Add code-signing as a final step, this will just use ad-hoc signing which may not be suitable in the long term but should help overcome some initial hurdles

Functionally there shouldn't be a huge amount that's changed. To build an app bundle which _should_ be suitable for steam upload without any further modifications, just run:
`cmake --preset default -G Xcode -DUSE_STEAM=ON`
`cmake --build --preset default --config Release --target install`

Then the app will installed to `install/default` under the project root